### PR TITLE
call_user_func_array call - updated for PHP8

### DIFF
--- a/documents-git/includes/RationalOptionPages.php
+++ b/documents-git/includes/RationalOptionPages.php
@@ -252,7 +252,7 @@ class RationalOptionPages {
                         $params['callback'] = array( $this, $params['callback'] );
                     }
 
-                    call_user_func_array( 'add_settings_section', $params );
+                    call_user_func_array( 'add_settings_section', array_values($params) );
 
                     if ( !empty( $section_params['fields'] ) ) {
                         foreach ( $section_params['fields'] as $field_key => $field_params ) {
@@ -279,7 +279,7 @@ class RationalOptionPages {
                                 $params['callback'] = array( $this, $params['callback'] );
                             }
 
-                            call_user_func_array( 'add_settings_field', $params );
+                            call_user_func_array( 'add_settings_field',array_values($params));
                         }
                     }
                 }
@@ -302,7 +302,7 @@ class RationalOptionPages {
             // Finalize callback
             $params['callback'] = array( $this, $params['callback'] );
 
-            call_user_func_array( $page['function'], $params );
+            call_user_func_array( $page['function'], array_values($params));
         }
     }
 


### PR DESCRIPTION
https://www.drupal.org/project/drupal/issues/3174022

Example:

replacing:
call_user_func_array( 'add_settings_section', $params );

with:
call_user_func_array( 'add_settings_section', array_values($params) );